### PR TITLE
Add meta keywords supports

### DIFF
--- a/lib/jekyll/tagging.rb
+++ b/lib/jekyll/tagging.rb
@@ -115,6 +115,12 @@ module Jekyll
       tags.join(', ')
     end
 
+    def keywords(obj)
+      return '' if not obj['tags']
+      tags = obj['tags'].dup
+      tags.join(',')  
+    end
+
     def active_tag_data(site = Tagger.site)
       return site.config['tag_data'] unless site.config["ignored_tags"]
       site.config["tag_data"].reject { |tag, set| site.config["ignored_tags"].include? tag }


### PR DESCRIPTION
Usage:

``` html
<meta name="keywords" content="{{ post | keywords }}"> 
```

In markdown:

```
tags: [ruby, programming]
```

The output is:

``` html
<meta name="keywords" content="ruby,programming"> 
```

[Demo at my blog post](http://allenlsy.com/metaprogramming-ruby-distilled/)
