### PR TITLE
Fixed pretty permalinks: added trailing slash

### DIFF
--- a/lib/jekyll/tagging.rb
+++ b/lib/jekyll/tagging.rb
@@ -112,7 +112,7 @@ module Jekyll
 
     def tag_url(tag, type = :page, site = Tagger.site)
       url = File.join('', site.config["tag_#{type}_dir"], ERB::Util.u(tag))
-      site.permalink_style == :pretty || site.config['tag_permalink_style'] == 'pretty' ? url : url << '.html'
+      site.permalink_style == :pretty || site.config['tag_permalink_style'] == 'pretty' ? url << '/' : url << '.html'
     end
 
     def tags(obj)


### PR DESCRIPTION
Hi, Jekyll creates pretty permalinks with trailing slash, and most servers with default settings send a "301 moved permanently", if one tries to access a static directory without the slash. So, this little change is to unify the tag urls with everything else.