### PR TITLE
Fix tag_url for when base_url is set in config

### DIFF
--- a/lib/jekyll/tagging.rb
+++ b/lib/jekyll/tagging.rb
@@ -111,7 +111,7 @@ module Jekyll
     end
 
     def tag_url(tag, type = :page, site = Tagger.site)
-      url = File.join('', site.config["tag_#{type}_dir"], ERB::Util.u(tag))
+      url = File.join('', site.config["baseurl"], site.config["tag_#{type}_dir"], ERB::Util.u(tag))
       site.permalink_style == :pretty || site.config['tag_permalink_style'] == 'pretty' ? url << '/' : url << '.html'
     end
 


### PR DESCRIPTION
I run my blog at `/tech` - the tag links were broken without this. I've tested locally removing the `baseurl` setting and it worked too.