### PR TITLE
Add ability to append extra data to all tag pages

### DIFF
--- a/README.rdoc
+++ b/README.rdoc
@@ -43,6 +43,14 @@ If your Jekyll <tt>permalink</tt> configuration is set to something other than <
 === Ignoring tags
 
 Sometimes you don't want tag pages generated for certain pages. That's ok! Just add <tt>ignored_tags: [tags,to,ignore]</tt> to your <tt>_config.yml</tt>
+
+=== Extra data on tag pages
+
+You can attach extra data to generated tag pages by specifying <tt>tag_page_data</tt> in <tt>_config.yml</tt> (this also works for <tt>tag_feed_data</tt>). For example, you might want to exclude tag pages from being picked up by `jekyll-sitemap`:
+
+  tag_page_data:
+    sitemap: false
+
 === Example tag page layout
 
 (Save this to <tt>_layouts/tag_page.html</tt> if using the <tt>_config.yml</tt> snippet above.)

--- a/lib/jekyll/tagging.rb
+++ b/lib/jekyll/tagging.rb
@@ -48,7 +48,8 @@ module Jekyll
     def new_tag(tag, posts)
       self.class.types.each { |type|
         if layout = site.config["tag_#{type}_layout"]
-          data = { 'layout' => layout, 'posts' => posts.sort.reverse!, 'tag' => tag }
+          data = site.config["tag_#{type}_data"] || {}
+          data.merge!('layout' => layout, 'posts' => posts.sort.reverse!, 'tag' => tag)
 
           name = yield data if block_given?
           name ||= tag

--- a/lib/jekyll/tagging.rb
+++ b/lib/jekyll/tagging.rb
@@ -48,8 +48,8 @@ module Jekyll
     def new_tag(tag, posts)
       self.class.types.each { |type|
         if layout = site.config["tag_#{type}_layout"]
-          data = site.config["tag_#{type}_data"] || {}
-          data.merge!('layout' => layout, 'posts' => posts.sort.reverse!, 'tag' => tag)
+          data = { 'layout' => layout, 'posts' => posts.sort.reverse!, 'tag' => tag }
+          data.merge!(site.config["tag_#{type}_data"] || {})
 
           name = yield data if block_given?
           name ||= tag


### PR DESCRIPTION
I had a need to do the thing mentioned in the readme example, so I made this change to enable it. It should be safe, unobtrusive, backwards compatible, etc. with existing installs and configs.