### PR TITLE
Fixed the missing title in the tag_page_layout page.

### DIFF
--- a/lib/jekyll/tagging.rb
+++ b/lib/jekyll/tagging.rb
@@ -106,6 +106,8 @@ module Jekyll
       self.content = data.delete('content') || ''
       self.data    = data
 
+      self.data['title'] = site.layouts[site.config['tag_page_layout']].data['title'] || site.config['tag_page_title'] || "Tag #{data['tag']}"
+
       super(site, base, dir[-1, 1] == '/' ? dir : '/' + dir, name)
     end
 


### PR DESCRIPTION
Without this patch the title is always left empty within the tags page nevertheless specified in the front matter of the layout page itself.