### PR TITLE
Make tags and tag cloud separators configurable

### DIFF
--- a/README.rdoc
+++ b/README.rdoc
@@ -55,6 +55,13 @@ If your Jekyll <tt>permalink</tt> configuration is set to something other than <
 
 Sometimes you don't want tag pages generated for certain pages. That's ok! Just add <tt>ignored_tags: [tags,to,ignore]</tt> to your <tt>_config.yml</tt>
 
+=== Custom separators
+
+You can change the separators used by the <tt>tags</tt> and <tt>tag_cloud</tt> filters in <tt>_config.yml</tt>. The defaults are:
+
+  tag_separator: ', '
+  tag_cloud_separator: ' '
+
 === Extra data on tag pages
 
 You can attach extra data to generated tag pages by specifying <tt>tag_page_data</tt> in <tt>_config.yml</tt> (this also works for <tt>tag_feed_data</tt>). For example, you might want to exclude tag pages from being picked up by `jekyll-sitemap`:

--- a/lib/jekyll/tagging.rb
+++ b/lib/jekyll/tagging.rb
@@ -120,9 +120,16 @@ module Jekyll
     include Helpers
 
     def tag_cloud(site)
+      separator =
+        if Tagger.site.config['tag_cloud_separator']
+          Tagger.site.config['tag_cloud_separator'].to_s
+        else
+          ' '
+        end
+
       active_tag_data.map { |tag, set|
         tag_link(tag, tag_url(tag), :class => "set-#{set}")
-      }.join(' ')
+      }.join(separator)
     end
 
     def tag_link(tag, url = tag_url(tag), html_opts = nil)
@@ -136,10 +143,17 @@ module Jekyll
     end
 
     def tags(obj)
+      separator =
+        if Tagger.site.config['tag_separator']
+          Tagger.site.config['tag_separator'].to_s
+        else
+          ', '
+        end
+
       tags = obj['tags'].dup
       tags.map! { |t| t.first } if tags.first.is_a?(Array)
       tags.map! { |t| tag_link(t, tag_url(t), :rel => 'tag') if t.is_a?(String) }.compact!
-      tags.join(', ')
+      tags.join(separator)
     end
 
     def keywords(obj)


### PR DESCRIPTION
Currently joining tags for a post with a comma and joining tags in a tag cloud with a whitespace is hardcoded. To accommodate the need to change those separators without complex CSS tricks, new config options `tag_separator` and `tag_cloud_separator` have been added.

Closes #63.