### PR TITLE
Make tags metadata optional per page

### DIFF
--- a/lib/jekyll/tagging.rb
+++ b/lib/jekyll/tagging.rb
@@ -137,6 +137,7 @@ module Jekyll
 
     def tags(obj)
       tags = obj['tags'].dup
+      return unless tags
       tags.map! { |t| t.first } if tags.first.is_a?(Array)
       tags.map! { |t| tag_link(t, tag_url(t), :rel => 'tag') if t.is_a?(String) }.compact!
       tags.join(', ')


### PR DESCRIPTION
After upgrading Jekyll from 1.1.2j to 3.8.3 and jekyll-tagging from 1.0.1 to
1.1.0, having pages with no tags metadata causes builds to fail:

	$ jekyll build
	Configuration file: /Users/asumner/code/everyday-rails/_config.yml
    Source: /Users/asumner/code/everyday-rails
    Destination: ./_site
  Incremental build: disabled. Enable with --incremental
  Generating...
	Liquid Exception: undefined method `first' for nil:NilClass in /_layouts/post.html
	jekyll 3.8.3 | Error:  undefined method `first' for nil:NilClass

Fix by making the tags metadata optional per page. If the "tags" option isn't
found, don't try to make a tags list.