### PR TITLE
fix!: use Jekyll's slug generation for the URLs

### DIFF
--- a/lib/jekyll/tagging.rb
+++ b/lib/jekyll/tagging.rb
@@ -12,7 +12,7 @@ module Jekyll
     # Substitutes any diacritics in _str_ with their ASCII equivalents,
     # whitespaces with dashes and converts _str_ to downcase.
     def jekyll_tagging_slug(str)
-      str.to_s.replace_diacritics.downcase.gsub(/\s/, '-')
+      Jekyll::Utils::slugify(str.to_s, mode: 'latin', cased: true)
     end
 
   end


### PR DESCRIPTION
Alternative approach fix #53, compared to #64. As it changes the generated URLs in certain cases, it might be considered a breaking change.

Also with this implemented, there is no need for #73 .