### PR TITLE
feat: enable to include tag in the generated page title

### DIFF
--- a/README.rdoc
+++ b/README.rdoc
@@ -62,6 +62,13 @@ You can attach extra data to generated tag pages by specifying <tt>tag_page_data
   tag_page_data:
     sitemap: false
 
+==== Page title including the tag name
+
+Specifically for the generated pages, there is an option to include the tag name into the title via `%{tag}`, for example:
+
+  tag_page_data:
+    title: "Posts tagged #%{tag}" # will generate title 'Posts tagged #news'
+
 === Example tag page layout
 
 (Save this to <tt>_layouts/tag_page.html</tt> if using the <tt>_config.yml</tt> snippet above.)

--- a/lib/jekyll/tagging.rb
+++ b/lib/jekyll/tagging.rb
@@ -50,6 +50,12 @@ module Jekyll
         if layout = site.config["tag_#{type}_layout"]
           data = { 'layout' => layout, 'posts' => posts.sort.reverse!, 'tag' => tag }
           data.merge!(site.config["tag_#{type}_data"] || {})
+          # interpolate optional tag in the title
+          if (data['title'])
+            data['title'] = data['title'] % { 'tag': data['tag'] }
+          else
+            data['title'] = "Posts tagged #%{tag}" % { 'tag': data['tag'] }
+          end
 
           name = yield data if block_given?
           name ||= tag


### PR DESCRIPTION
This might be an alternative approach to #60, to allow interpolating the tag directly into the existing `title` data from config file.